### PR TITLE
replace angles set  for  2nd source orbit

### DIFF
--- a/source/MulensModel/modelparameters.py
+++ b/source/MulensModel/modelparameters.py
@@ -318,14 +318,16 @@ class ModelParameters(object):
                 raise KeyError('xallarap model with 2 sources requires ' + key)
 
         parameters_2['xi_semimajor_axis'] /= q_source
-        self._add_180_and_correct_to_360(parameters_2, 'xi_argument_of_latitude_reference')
-        self._add_180_and_correct_to_360(parameters_2, 'xi_omega_periapsis')
+        parameters_2['xi_argument_of_latitude_reference'] = self._add_180_and_wrap_to_360(
+            parameters_2['xi_argument_of_latitude_reference'])
+        if 'xi_omega_periapsis' in parameters_2:
+            parameters_2['xi_omega_periapsis'] = self._add_180_and_wrap_to_360(parameters_2['xi_omega_periapsis'])
 
-    def _add_180_and_correct_to_360(self, parameters, key):
-        """In given dict (parameters) add 180 to given key and subtract 360, it the result is larger than that"""
-        parameters[key] += 180.
-        if parameters[key] > 360.:
-            parameters[key] -= 360.
+    def _add_180_and_wrap_to_360(self, value):
+        """add 180 to the value and wrap angle to 360"""
+        value += 180.
+        value %= 360.
+        return value
 
     def __repr__(self):
         """A nice way to represent a ModelParameters object as a string"""
@@ -829,8 +831,8 @@ class ModelParameters(object):
                 value /= self.parameters['q_source']
                 setattr(self._source_2_parameters, parameter, value)
             elif parameter in ['xi_argument_of_latitude_reference', 'xi_omega_periapsis']:
-                self._add_180_and_correct_to_360(self._source_2_parameters.parameters, parameter)
-
+                value = self._add_180_and_wrap_to_360(value)
+                setattr(self._source_2_parameters, parameter, value)
             self._update_sources_xallarap_reference()
 
     def _get_uniform_caustic_sampling(self):


### PR DESCRIPTION
## Summary by Sourcery

Refactor angle adjustment to use modulo wrapping and update angle parameters for the second source accordingly

Enhancements:
- Replace _add_180_and_correct_to_360 with _add_180_and_wrap_to_360 that uses modulo 360 for angle wrapping
- Update _set_changed_parameters_2nd_source to apply the new wrapping helper for xi_argument_of_latitude_reference and conditional xi_omega_periapsis
- Update _update_sources to apply the new wrapping helper when setting xi_argument_of_latitude_reference and xi_omega_periapsis