### PR TITLE
Ex_16_mix_starting_parameters

### DIFF
--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -47,7 +47,7 @@ except Exception:
     raise ImportError('\nYou have to install MulensModel first!\n')
 
 
-__version__ = '0.55.0'
+__version__ = '0.55.1'
 
 
 class UlensModelFit(object):

--- a/examples/example_16/ulens_model_fit.py
+++ b/examples/example_16/ulens_model_fit.py
@@ -3094,7 +3094,7 @@ class UlensModelFit(object):
         if key in self._fit_constraints:
             prior_type, power, sigma, datasets = self._fit_constraints[key]
 
-            rho_ratio = self._model.parameters.parameters['rho_1']/self._model.parameters.parameters['rho_2']**power
+            rho_ratio = (self._model.parameters.parameters['rho_1']/self._model.parameters.parameters['rho_2'])**power
             for i, dataset in enumerate(self._datasets):
                 if i in datasets:
                     index1 = self._get_index_of_flux(i, 0)


### PR DESCRIPTION
## Summary by Sourcery

Bump the example Ulens model fitting script version and correct the exponent placement in the 2-source size prior calculation to apply the power to the full rho ratio.

Bug Fixes:
- Fix the 2-source size prior rho ratio calculation so that the exponent is applied to the entire rho_1/rho_2 ratio instead of only rho_2.

Enhancements:
- Update the example Ulens model fitting script version from 0.55.0 to 0.55.1 to reflect the latest changes.